### PR TITLE
Fix string validation

### DIFF
--- a/upload/framework/CAT/Helper/Validate.php
+++ b/upload/framework/CAT/Helper/Validate.php
@@ -346,7 +346,9 @@ if (!class_exists('CAT_Helper_Validate'))
 
         public static function validate_string($string)
         {
-            return filter_var($string, FILTER_VALIDATE_STRING);
+            // FILTER_VALIDATE_STRING does not exist; ensure we actually have
+            // a string and return it, or false otherwise
+            return is_string($string) ? $string : false;
         }
         public static function validate_ip($ip)
         {


### PR DESCRIPTION
## Summary
- fix validate_string to avoid using nonexistent constant

## Testing
- `php -l upload/framework/CAT/Helper/Validate.php`


------
https://chatgpt.com/codex/tasks/task_e_68836b74bdac8330a9460733ec24ba5a