### PR TITLE
Handle null root-scope array access in Dwoo compiler

### DIFF
--- a/upload/modules/lib_dwoo/dwoo/Dwoo/Compiler.php
+++ b/upload/modules/lib_dwoo/dwoo/Dwoo/Compiler.php
@@ -554,7 +554,7 @@ class Dwoo_Compiler implements Dwoo_ICompiler
 	 *
 	 * @param Dwoo_Security_Policy $policy the security policy object
 	 */
-	public function setSecurityPolicy(Dwoo_Security_Policy $policy = null)
+        public function setSecurityPolicy(?Dwoo_Security_Policy $policy = null)
 	{
 		$this->securityPolicy = $policy;
 	}
@@ -2352,10 +2352,12 @@ class Dwoo_Compiler implements Dwoo_ICompiler
 						array_shift($m[1]);
 					}
 
-					if ($curBlock !== 'root') {
-						$output = '(isset('.$output.') ? '.$output.':null)';
-					}
-				}
+                                        if ($curBlock !== 'root') {
+                                                $output = '(isset('.$output.') ? '.$output.':null)';
+                                        } elseif (strpos($output, '$this->scope[') === 0) {
+                                                $output = '(isset('.$output.') ? '.$output.' : "")';
+                                        }
+                                }
 
 				if (count($m[2])) {
 					unset($m[0]);

--- a/upload/modules/lib_dwoo/dwoo/Dwoo/ICompiler.php
+++ b/upload/modules/lib_dwoo/dwoo/Dwoo/ICompiler.php
@@ -45,5 +45,5 @@ interface Dwoo_ICompiler
 	 *
 	 * @param Dwoo_Security_Policy $policy the security policy object
 	 */
-	public function setSecurityPolicy(Dwoo_Security_Policy $policy = null);
+        public function setSecurityPolicy(?Dwoo_Security_Policy $policy = null);
 }

--- a/upload/modules/lib_dwoo/dwoo/Dwoo/ITemplate.php
+++ b/upload/modules/lib_dwoo/dwoo/Dwoo/ITemplate.php
@@ -71,7 +71,7 @@ interface Dwoo_ITemplate
 	 * @param Dwoo_ICompiler $compiler the compiler that must be used
 	 * @return string
 	 */
-	public function getCompiledTemplate(Dwoo $dwoo, Dwoo_ICompiler $compiler = null);
+        public function getCompiledTemplate(Dwoo $dwoo, ?Dwoo_ICompiler $compiler = null);
 
 	/**
 	 * returns the template name
@@ -146,5 +146,5 @@ interface Dwoo_ITemplate
 	 * 											an include, extends or any other plugin)
 	 * @return Dwoo_ITemplate|null|false
 	 */
-	public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, Dwoo_ITemplate $parentTemplate = null);
+        public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, ?Dwoo_ITemplate $parentTemplate = null);
 }

--- a/upload/modules/lib_dwoo/dwoo/Dwoo/Template/File.php
+++ b/upload/modules/lib_dwoo/dwoo/Dwoo/Template/File.php
@@ -183,10 +183,10 @@ class Dwoo_Template_File extends Dwoo_Template_String
 	 * 											an include, extends or any other plugin)
 	 * @return Dwoo_Template_File|null
 	 */
-	public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, Dwoo_ITemplate $parentTemplate = null)
-	{
-		if (DIRECTORY_SEPARATOR === '\\') {
-			$resourceId = str_replace(array("\t", "\n", "\r", "\f", "\v"), array('\\t', '\\n', '\\r', '\\f', '\\v'), $resourceId);
+        public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, ?Dwoo_ITemplate $parentTemplate = null)
+        {
+                if (DIRECTORY_SEPARATOR === '\\') {
+                        $resourceId = str_replace(array("\t", "\n", "\r", "\f", "\v"), array('\\t', '\\n', '\\r', '\\f', '\\v'), $resourceId);
 		}
 		$resourceId = strtr($resourceId, '\\', '/');
 

--- a/upload/modules/lib_dwoo/dwoo/Dwoo/Template/String.php
+++ b/upload/modules/lib_dwoo/dwoo/Dwoo/Template/String.php
@@ -335,7 +335,7 @@ class Dwoo_Template_String implements Dwoo_ITemplate
 	 * @param Dwoo_ICompiler $compiler the compiler that must be used
 	 * @return string
 	 */
-	public function getCompiledTemplate(Dwoo $dwoo, Dwoo_ICompiler $compiler = null)
+        public function getCompiledTemplate(Dwoo $dwoo, ?Dwoo_ICompiler $compiler = null)
 	{
 		$compiledFile = $this->getCompiledFilename($dwoo);
 
@@ -404,10 +404,10 @@ class Dwoo_Template_String implements Dwoo_ITemplate
 	 * 											an include, extends or any other plugin)
 	 * @return Dwoo_Template_String
 	 */
-	public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, Dwoo_ITemplate $parentTemplate = null)
-	{
-		return new self($resourceId, $cacheTime, $cacheId, $compileId);
-	}
+        public static function templateFactory(Dwoo $dwoo, $resourceId, $cacheTime = null, $cacheId = null, $compileId = null, ?Dwoo_ITemplate $parentTemplate = null)
+        {
+                return new self($resourceId, $cacheTime, $cacheId, $compileId);
+        }
 
 	/**
 	 * returns the full compiled file name and assigns a default value to it if


### PR DESCRIPTION
## Summary
- wrap root-scope nested variable access in isset checks to avoid PHP warnings when scope entries are null

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693709a6aef48330a3feaac9a5a954ca)